### PR TITLE
New data selection method

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -4,8 +4,9 @@
     "userId": "",
     "playlistId": "",
     "radioTrackserviceUrl": "http://fm4.orf.at/trackservicepopup/main",
+    "radioEntrySelector": "td[width=300]>font>br",
     "radioTitleSelector": "b",
     "radioArtistSelector": "i",
-    "fm4": true,
+    "searchLinear": true,
     "localEnvironment": true
 }

--- a/main.js
+++ b/main.js
@@ -47,8 +47,10 @@ function getRadioTracks(trackserviceUrl){
                     $title = $entry.nextAll(config.radioTitleSelector).first();
                     $artist = $entry.nextAll(config.radioArtistSelector).first();
                 }
-                $title = $title.text().trim().replace(/^\s-\s/, '');
-                $artist = $artist.text().trim().replace(/^\s-\s/, '');
+
+                String.prototype.trimEx = function() { return this.trim().replace(/^\s?-\s/, ''); }
+                $title = $title.text().trimEx();
+                $artist = $artist.text().trimEx();
 
                 String.prototype.isEmpty = function() { return (!this || !this.length); }
                 if ($title.isEmpty() || $artist.isEmpty())

--- a/readme.md
+++ b/readme.md
@@ -14,9 +14,8 @@ Before running it on the server you need to authenticate via oAuth (as the user 
 
 1. Clone this repo into a local directory
 2. Copy `config.example.json` to `config.json` and insert your own credentials & radio station.
-You can obtain a clientId & clientSecret by [registering a new application](https://developer.spotify.com/my-applications/#!/applications).
-You can use the predefined radio settings for [Radio FM4](http://fm4.orf.at) or define settings for your own radio station. You need a URL to a page that lists the recently played tracks and a jQuery style selector for title and artist. I added a flag for FM4s weird HTML markup - this should be set to false for others.
-I have tested only [one other radio station](http://www.novaplanet.com/radionova), so this may require some adjustments in the code for other stations.
+You can obtain a clientId & clientSecret by [registering a new application](https://developer.spotify.com/my-applications/#!/applications).  
+There are some pre-defined and tested radio stations, they can be found in `station-examples.md`. You can define your own schemes, all you need is the URL of the playlist page of the station and three jQuery selectors: one for the playlist entry element, one for the title and one for the artist. Some radio stations (like FM4) have special markup that requires linear instead of nested search; this behaviour can be set with the `searchLinear` flag.
 3. Run `npm install`
 4. Run `node main.js`
 5. Open the displayed URL in your browser & grant permission for your app to change your playlists. This will open a page on localhost which you can close. Now you find two new files: `accessToken` and `refreshToken`. They contain the secret information to authenticate the user with spotify, so handle with care!

--- a/station-examples.md
+++ b/station-examples.md
@@ -1,0 +1,41 @@
+# Radio station examples
+
+Here you can find some examples for configurations for various radio stations.
+
+All URLs and selectors valid as of 2016-01-03.
+
+## BBC Radio
+
+Works for *radio1*, *1xtra*, *radio2*, *6music* and *radioscotland* (adjust the URL if you want one of these stations).
+
+    "radioTrackserviceUrl": "http://www.bbc.co.uk/radio1/playlist",
+    "radioEntrySelector": "div.pll-playlist-item-details",
+    "radioTitleSelector": "div.pll-playlist-item-title",
+    "radioArtistSelector": "div.pll-playlist-item-artist > a",
+    "searchLinear": false,
+
+## ORF FM4
+
+This radio station needs the linear search.
+
+    "radioTrackserviceUrl": "http://fm4.orf.at/trackservicepopup/main",
+    "radioEntrySelector": "td[width=300]>font>br",
+    "radioTitleSelector": "b",
+    "radioArtistSelector": "i",
+    "searchLinear": true,
+
+## Radio Nova
+
+    "radioTrackserviceUrl": "http://www.novaplanet.com/radionova/cetaitquoicetitre/",
+    "radioEntrySelector": "div.cestquoicetitre_results>div.resultat>div.info-col",
+    "radioTitleSelector": "h3.titre",
+    "radioArtistSelector": "h2.artiste",
+    "searchLinear": false,
+
+## NDR2
+
+    "radioTrackserviceUrl": "http://www.ndr.de/ndr2/programm/titelliste1202.html",
+    "radioEntrySelector": "div#playlist>ul>li.program>div.details>h3",
+    "radioTitleSelector": "span.title",
+    "radioArtistSelector": "span.artist",
+    "searchLinear": false,

--- a/station-examples.md
+++ b/station-examples.md
@@ -39,3 +39,11 @@ This radio station needs the linear search.
     "radioTitleSelector": "span.title",
     "radioArtistSelector": "span.artist",
     "searchLinear": false,
+
+## FluxFM
+
+    "radioTrackserviceUrl": "http://www.fluxfm.de/fluxfm-playlist/",
+    "radioEntrySelector": "table#songs>tr>td.title>div",
+    "radioTitleSelector": "span.song",
+    "radioArtistSelector": "span.artist",
+    "searchLinear": false,


### PR DESCRIPTION
Most radio stations' playlists feature nested markup for playlist entries, each containing the artist and title. With regard to this, the new method selects individual playlist entries and fetches the track data from those instead of parsing the file in a (more or less) linear way. A slightly modified linear scan mode is still present for stations with less-than-ideal markup.
Also more stations have been tested and added, including the required data selectors.
